### PR TITLE
Restructure CMake code to allow external usage

### DIFF
--- a/BlockLibConfig.cmake.in
+++ b/BlockLibConfig.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+
+set(PARSER_EXECUTABLE ${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_BINDIR@/parse_registrations)
+
+include("${CMAKE_CURRENT_LIST_DIR}/BlockLibTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/BlockLibMacros.cmake")

--- a/BlockLibMacros.cmake.in
+++ b/BlockLibMacros.cmake.in
@@ -1,0 +1,76 @@
+# define global block building command
+
+function(gr_generate_block_instantiations LIB_NAME)
+    set(options "SPLIT_BLOCK_INSTANTIATIONS")
+    set(oneValueArgs "")
+    set(multiValueArgs HEADERS SOURCES)
+    cmake_parse_arguments(CBL "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if (NOT TARGET ${LIB_NAME})
+        message(FATAL_ERROR "${LIB_NAME} is not a target")
+    endif()
+
+    if (NOT CBL_HEADERS)
+        message(FATAL_ERROR "No headers passed to gr_generate_block_instantiations")
+    endif()
+
+    # directory where parse_registrations will output .cpp files.
+    set(GEN_DIR "${CMAKE_BINARY_DIR}/generated_plugins/${LIB_NAME}")
+    file(MAKE_DIRECTORY "${GEN_DIR}")
+
+    set(GEN_CPP_LIST "")
+    foreach(HDR IN LISTS CBL_HEADERS)
+        get_filename_component(ABS_HDR "${HDR}" ABSOLUTE)
+        get_filename_component(BASENAME "${HDR}" NAME_WE)
+
+        # remove any previously generated .cpp files for this header.
+        file(GLOB OLD_FILES "${GEN_DIR}/${BASENAME}*.cpp")
+        if(OLD_FILES)
+            message(STATUS "deleting old generated files ${OLD_FILES}")
+            file(REMOVE ${OLD_FILES})
+        endif()
+
+        if(GR_SPLIT_BLOCK_INSTANTIATIONS OR CBL_SPLIT_BLOCK_INSTANTIATIONS)
+            set(PARSER_SPLIT_OPTION "--split")
+        else()
+            set(PARSER_SPLIT_OPTION "")
+        endif()
+
+        message(STATUS "Generating code for header: ${ABS_HDR} -> ${GEN_DIR} with PARSER_SPLIT_OPTION=${PARSER_SPLIT_OPTION}")
+
+        # BlockLibConfig.cmake sets this when BlockLib is found via find_package
+        # However when FetchContent is used that doesn't happen, so fall back to the build path
+        if (NOT PARSER_EXECUTABLE)
+            set(PARSER_EXECUTABLE @PROJECT_BINARY_DIR@/tools_build/parse_registrations)
+        endif()
+
+        # run the parser tool immediately at configuration time.
+        execute_process(
+                COMMAND ${PARSER_EXECUTABLE} "${ABS_HDR}" "${GEN_DIR}" ${PARSER_SPLIT_OPTION}
+                RESULT_VARIABLE gen_res
+                OUTPUT_VARIABLE gen_out
+                ERROR_VARIABLE gen_err
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_STRIP_TRAILING_WHITESPACE
+        )
+        message(STATUS "Output from parse_registrations for ${ABS_HDR}:\n${gen_out}")
+        if(NOT gen_res EQUAL 0)
+            message(FATAL_ERROR "Error running parse_registrations on ${HDR}: ${gen_err}")
+        endif()
+
+        # Glob for the generated .cpp files.
+        file(GLOB GENERATED_FILES "${GEN_DIR}/${BASENAME}*.cpp")
+        if(NOT GENERATED_FILES)
+            # If no .cpp files were generated, create a dummy file.
+            set(DUMMY_CPP "${GEN_DIR}/dummy_${BASENAME}.cpp")
+            file(WRITE "${DUMMY_CPP}" "// No macros or expansions found for '${BASENAME}'\n")
+            list(APPEND GENERATED_FILES "${DUMMY_CPP}")
+        endif()
+
+        list(APPEND GEN_CPP_LIST ${GENERATED_FILES})
+    endforeach()
+
+    target_sources(${LIB_NAME} PRIVATE ${GEN_CPP_LIST})
+
+    target_link_libraries(${LIB_NAME} PRIVATE BlockLib::Registry)
+endfunction()

--- a/BlockLibMacros.cmake.in
+++ b/BlockLibMacros.cmake.in
@@ -36,6 +36,8 @@ function(gr_generate_block_instantiations LIB_NAME)
             set(PARSER_SPLIT_OPTION "")
         endif()
 
+        set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${HDR})
+
         message(STATUS "Generating code for header: ${ABS_HDR} -> ${GEN_DIR} with PARSER_SPLIT_OPTION=${PARSER_SPLIT_OPTION}")
 
         # BlockLibConfig.cmake sets this when BlockLib is found via find_package

--- a/BlockLibMacros.cmake.in
+++ b/BlockLibMacros.cmake.in
@@ -24,7 +24,7 @@ function(gr_generate_block_instantiations LIB_NAME)
         get_filename_component(BASENAME "${HDR}" NAME_WE)
 
         # remove any previously generated .cpp files for this header.
-        file(GLOB OLD_FILES "${GEN_DIR}/${BASENAME}*.cpp")
+        file(GLOB OLD_FILES "${GEN_DIR}/*${BASENAME}*.cpp")
         if(OLD_FILES)
             message(STATUS "deleting old generated files ${OLD_FILES}")
             file(REMOVE ${OLD_FILES})

--- a/BlockLibMacros.cmake.in
+++ b/BlockLibMacros.cmake.in
@@ -20,44 +20,51 @@ function(gr_generate_block_instantiations LIB_NAME)
 
     set(GEN_CPP_LIST "")
     foreach(HDR IN LISTS CBL_HEADERS)
-        get_filename_component(ABS_HDR "${HDR}" ABSOLUTE)
-        get_filename_component(BASENAME "${HDR}" NAME_WE)
 
-        # remove any previously generated .cpp files for this header.
-        file(GLOB OLD_FILES "${GEN_DIR}/*${BASENAME}*.cpp")
-        if(OLD_FILES)
-            message(STATUS "deleting old generated files ${OLD_FILES}")
-            file(REMOVE ${OLD_FILES})
-        endif()
+        # Try to only run the generation when the header is newer than the last time
+        file(TIMESTAMP ${HDR} modified "%s")
+        if (NOT DEFINED modified_${HDR} OR ${modified} GREATER modified_${HDR})
+            set(modified_${HDR} ${modified} CACHE STRING "Last generated time" FORCE)
 
-        if(GR_SPLIT_BLOCK_INSTANTIATIONS OR CBL_SPLIT_BLOCK_INSTANTIATIONS)
-            set(PARSER_SPLIT_OPTION "--split")
-        else()
-            set(PARSER_SPLIT_OPTION "")
-        endif()
+            get_filename_component(ABS_HDR "${HDR}" ABSOLUTE)
+            get_filename_component(BASENAME "${HDR}" NAME_WE)
 
-        set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${HDR})
+            # remove any previously generated .cpp files for this header.
+            file(GLOB OLD_FILES "${GEN_DIR}/*${BASENAME}*.cpp")
+            if(OLD_FILES)
+                message(STATUS "deleting old generated files ${OLD_FILES}")
+                file(REMOVE ${OLD_FILES})
+            endif()
 
-        message(STATUS "Generating code for header: ${ABS_HDR} -> ${GEN_DIR} with PARSER_SPLIT_OPTION=${PARSER_SPLIT_OPTION}")
+            if(GR_SPLIT_BLOCK_INSTANTIATIONS OR CBL_SPLIT_BLOCK_INSTANTIATIONS)
+                set(PARSER_SPLIT_OPTION "--split")
+            else()
+                set(PARSER_SPLIT_OPTION "")
+            endif()
 
-        # BlockLibConfig.cmake sets this when BlockLib is found via find_package
-        # However when FetchContent is used that doesn't happen, so fall back to the build path
-        if (NOT PARSER_EXECUTABLE)
-            set(PARSER_EXECUTABLE @PROJECT_BINARY_DIR@/tools_build/parse_registrations)
-        endif()
+            set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${HDR})
 
-        # run the parser tool immediately at configuration time.
-        execute_process(
-                COMMAND ${PARSER_EXECUTABLE} "${ABS_HDR}" "${GEN_DIR}" ${PARSER_SPLIT_OPTION}
-                RESULT_VARIABLE gen_res
-                OUTPUT_VARIABLE gen_out
-                ERROR_VARIABLE gen_err
-                OUTPUT_STRIP_TRAILING_WHITESPACE
-                ERROR_STRIP_TRAILING_WHITESPACE
-        )
-        message(STATUS "Output from parse_registrations for ${ABS_HDR}:\n${gen_out}")
-        if(NOT gen_res EQUAL 0)
-            message(FATAL_ERROR "Error running parse_registrations on ${HDR}: ${gen_err}")
+            message(STATUS "Generating code for header: ${ABS_HDR} -> ${GEN_DIR} with PARSER_SPLIT_OPTION=${PARSER_SPLIT_OPTION}")
+
+            # BlockLibConfig.cmake sets this when BlockLib is found via find_package
+            # However when FetchContent is used that doesn't happen, so fall back to the build path
+            if (NOT PARSER_EXECUTABLE)
+                set(PARSER_EXECUTABLE @PROJECT_BINARY_DIR@/tools_build/parse_registrations)
+            endif()
+
+            # run the parser tool immediately at configuration time.
+            execute_process(
+                    COMMAND ${PARSER_EXECUTABLE} "${ABS_HDR}" "${GEN_DIR}" ${PARSER_SPLIT_OPTION}
+                    RESULT_VARIABLE gen_res
+                    OUTPUT_VARIABLE gen_out
+                    ERROR_VARIABLE gen_err
+                    OUTPUT_STRIP_TRAILING_WHITESPACE
+                    ERROR_STRIP_TRAILING_WHITESPACE
+            )
+            message(STATUS "Output from parse_registrations for ${ABS_HDR}:\n${gen_out}")
+            if(NOT gen_res EQUAL 0)
+                message(FATAL_ERROR "Error running parse_registrations on ${HDR}: ${gen_err}")
+            endif()
         endif()
 
         # Glob for the generated .cpp files.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,15 +5,17 @@ set(CMAKE_CXX_STANDARD 23)
 
 option(ENABLE_SPLIT "Enable splitting of generated files (pass --split to the parser)" ON)
 
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
 
 # --------------------------------------------------------------------------
 # Manually configure and build the parser tool in a separate directory
 # --------------------------------------------------------------------------
-set(TOOLS_BUILD_DIR "${CMAKE_BINARY_DIR}/tools_build")
+set(TOOLS_BUILD_DIR "${PROJECT_BINARY_DIR}/tools_build")
 if(NOT EXISTS "${TOOLS_BUILD_DIR}/CMakeCache.txt")
     message(STATUS "Configuring parser tool in ${TOOLS_BUILD_DIR}...")
     execute_process(
-            COMMAND ${CMAKE_COMMAND} -S ${CMAKE_SOURCE_DIR}/tools -B ${TOOLS_BUILD_DIR} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+            COMMAND ${CMAKE_COMMAND} -S ${PROJECT_SOURCE_DIR}/tools -B ${TOOLS_BUILD_DIR} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
             RESULT_VARIABLE config_result
             OUTPUT_VARIABLE config_output
             ERROR_VARIABLE config_error
@@ -50,72 +52,27 @@ endif()
 add_subdirectory(include)
 add_subdirectory(src)
 
-# define global block building command
+configure_file(BlockLibMacros.cmake.in BlockLibMacros.cmake @ONLY)
+
+include(${PROJECT_BINARY_DIR}/BlockLibMacros.cmake)
+
 function(create_block_library LIB_NAME)
     set(options "")
     set(oneValueArgs "")
     set(multiValueArgs HEADERS SOURCES)
     cmake_parse_arguments(CBL "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    # directory where parse_registrations will output .cpp files.
-    set(GEN_DIR "${CMAKE_BINARY_DIR}/generated_plugins/${LIB_NAME}")
-    file(MAKE_DIRECTORY "${GEN_DIR}")
-
-    set(GEN_CPP_LIST "")
-    foreach(HDR IN LISTS CBL_HEADERS)
-        get_filename_component(ABS_HDR "${HDR}" ABSOLUTE)
-        get_filename_component(BASENAME "${HDR}" NAME_WE)
-
-        # remove any previously generated .cpp files for this header.
-        file(GLOB OLD_FILES "${GEN_DIR}/${BASENAME}*.cpp")
-        if(OLD_FILES)
-            message(STATUS "deleting old generated files ${OLD_FILES}")
-            file(REMOVE ${OLD_FILES})
-        endif()
-
-        if(ENABLE_SPLIT)
-            set(PARSER_SPLIT_OPTION "--split")
-        else()
-            set(PARSER_SPLIT_OPTION "")
-        endif()
-
-        message(STATUS "Generating code for header: ${ABS_HDR} -> ${GEN_DIR} with PARSER_SPLIT_OPTION=${PARSER_SPLIT_OPTION}")
-
-        # run the parser tool immediately at configuration time.
-        execute_process(
-                COMMAND ${PARSER_EXECUTABLE} "${ABS_HDR}" "${GEN_DIR}" ${PARSER_SPLIT_OPTION}
-                RESULT_VARIABLE gen_res
-                OUTPUT_VARIABLE gen_out
-                ERROR_VARIABLE gen_err
-                OUTPUT_STRIP_TRAILING_WHITESPACE
-                ERROR_STRIP_TRAILING_WHITESPACE
-        )
-        message(STATUS "Output from parse_registrations for ${ABS_HDR}:\n${gen_out}")
-        if(NOT gen_res EQUAL 0)
-            message(FATAL_ERROR "Error running parse_registrations on ${HDR}: ${gen_err}")
-        endif()
-
-        # Glob for the generated .cpp files.
-        file(GLOB GENERATED_FILES "${GEN_DIR}/${BASENAME}*.cpp")
-        if(NOT GENERATED_FILES)
-            # If no .cpp files were generated, create a dummy file.
-            set(DUMMY_CPP "${GEN_DIR}/dummy_${BASENAME}.cpp")
-            file(WRITE "${DUMMY_CPP}" "// No macros or expansions found for '${BASENAME}'\n")
-            list(APPEND GENERATED_FILES "${DUMMY_CPP}")
-        endif()
-
-        list(APPEND GEN_CPP_LIST ${GENERATED_FILES})
-    endforeach()
-
     add_library(${LIB_NAME} SHARED
-            ${GEN_CPP_LIST}
             ${CBL_SOURCES}
     )
+
+    gr_generate_block_instantiations(${LIB_NAME} HEADERS ${CBL_HEADERS})
+
     target_include_directories(${LIB_NAME} PUBLIC
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
             $<INSTALL_INTERFACE:include>
-            "${CMAKE_SOURCE_DIR}/include"
     )
+
     set_target_properties(${LIB_NAME} PROPERTIES CXX_STANDARD 23)
     install(TARGETS ${LIB_NAME} LIBRARY DESTINATION lib)
 endfunction()
@@ -132,5 +89,23 @@ if (TARGET grBasic AND TARGET grMath)
     set_target_properties(grBlockLib PROPERTIES CXX_STANDARD 23)
     install(TARGETS grBlockLib LIBRARY DESTINATION lib)
 endif()
+
+set(CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/BlockLib")
+
+configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/BlockLibConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/BlockLibConfig.cmake"
+    INSTALL_DESTINATION ${CMAKECONFIG_INSTALL_DIR}
+)
+
+install(EXPORT BlockLibTargets DESTINATION ${CMAKECONFIG_INSTALL_DIR} NAMESPACE BlockLib::)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/BlockLibConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/BlockLibMacros.cmake"
+    DESTINATION "${CMAKECONFIG_INSTALL_DIR}"
+    COMPONENT Devel
+)
+
+install(PROGRAMS ${PARSER_EXECUTABLE} DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 add_subdirectory(example)

--- a/blocks/basic/CMakeLists.txt
+++ b/blocks/basic/CMakeLists.txt
@@ -19,7 +19,7 @@ create_block_library(grBasic
 )
 
 # optionally:
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/" DESTINATION include/gnuradio-4.x/basic FILES_MATCHING PATTERN "*.hpp")
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gnuradio-4.x/basic FILES_MATCHING PATTERN "*.hpp")
 
 if(ENABLE_TESTING)
     add_subdirectory(test)

--- a/blocks/math/CMakeLists.txt
+++ b/blocks/math/CMakeLists.txt
@@ -15,7 +15,7 @@ create_block_library(grMath
 )
 
 # optionally:
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/" DESTINATION include/gnuradio-4.x/math FILES_MATCHING PATTERN "*.hpp")
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gnuradio-4.x/math FILES_MATCHING PATTERN "*.hpp")
 
 if(ENABLE_TESTING)
     add_subdirectory(test)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,20 +1,15 @@
 # example/CMakeLists.txt
 
 add_library(gr_common INTERFACE)
-target_include_directories(gr_common INTERFACE
-        "${CMAKE_SOURCE_DIR}/include"
-        "${CMAKE_SOURCE_DIR}/blocks/basic/include"
-        "${CMAKE_SOURCE_DIR}/blocks/math/include"
-)
 
 add_executable(test_registry_basic main.cpp)
 add_executable(test_registry_math main.cpp)
 add_executable(test_registry_both main.cpp)
 add_executable(test_registry main.cpp)
 
-target_link_libraries(test_registry_basic PRIVATE gr_common grCore grBasic)
-target_link_libraries(test_registry_math PRIVATE gr_common grCore grMath)
-target_link_libraries(test_registry_both PRIVATE gr_common grCore grBasic grMath)
-target_link_libraries(test_registry PRIVATE gr_common grCore grBlockLib)
+target_link_libraries(test_registry_basic PRIVATE gr_common grCore grBasic BlockLib::Registry)
+target_link_libraries(test_registry_math PRIVATE gr_common grCore grMath grBasic BlockLib::Registry)
+target_link_libraries(test_registry_both PRIVATE gr_common grCore grBasic grMath BlockLib::Registry)
+target_link_libraries(test_registry PRIVATE gr_common grCore grBlockLib BlockLib::Registry)
 
 install(TARGETS test_registry RUNTIME DESTINATION bin)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,1 +1,12 @@
 # include/CMakeLists.txt
+
+add_library(Registry INTERFACE)
+add_library(BlockLib::Registry ALIAS Registry)
+
+target_include_directories(Registry INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/BlockLib>
+)
+
+install(TARGETS Registry EXPORT BlockLibTargets)
+install(FILES gr_registry.hpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/BlockLib)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,5 @@ add_library(grCore STATIC
         gr_registry.cpp
         # add other .cpp if needed
 )
-target_include_directories(grCore PUBLIC
-        "${CMAKE_SOURCE_DIR}/include"
-)
+
+target_link_libraries(grCore PRIVATE BlockLib::Registry)


### PR DESCRIPTION
- Add a CMake config file to allow finding the library via find_package
- Extract the registration handling into gr_generate_block_instantiations function
- Move the function into a separate CMake file
- Create an interface library for gr_registry.hpp to allow exporting and automatic include dir propagation
- Install generator program

This allows to use the library and the generation function from both find_package and FetchContent

See https://github.com/fair-acc/gnuradio4/issues/517